### PR TITLE
Fix missing headers

### DIFF
--- a/vptree.hpp
+++ b/vptree.hpp
@@ -9,6 +9,8 @@
 #include <random>
 #include <cmath>
 #include <stdexcept>
+#include <functional>
+#include <string>
 
 namespace vpt {
 


### PR DESCRIPTION
functional and string are required for std::function and std::to_string. It doesn't compile without these for me on Windows with VS2019.